### PR TITLE
Update data requests API to better handle projects, requests, and user actions PEDS-301

### DIFF
--- a/GEN3/project_request/requirements.md
+++ b/GEN3/project_request/requirements.md
@@ -36,7 +36,8 @@ Returns a list of project requests. If the user is a requester it would be a lis
             "value": "", // string
             "optional": true // bool
           }
-        ]
+        ],
+        "available_user_actions": [] // array of string ("SUBMIT" | "REQUEST_UPDATE" | "APPROVE" | "REJECT")
       }
     ],
     "searches": [
@@ -89,6 +90,7 @@ Returns a list of data requests with added information on requester user ("princ
         "optional": true // bool
       }
     ],
+    "available_user_actions": [], // array of string ("SUBMIT" | "REQUEST_UPDATE" | "APPROVE" | "REJECT")
     "project": {
       "id": 0, // number (int)
       "title": "", // string

--- a/GEN3/project_request/requirements.md
+++ b/GEN3/project_request/requirements.md
@@ -111,7 +111,6 @@ Updates a data request. Only certain properties are available to updates (see Re
 
 ```jsonc
 {
-  "state": "", // string
   "submitted_at": "", // string (timestamp) or null
   "completed_at": "", // string (timestamp) or null
   "attributes": [

--- a/GEN3/project_request/requirements.md
+++ b/GEN3/project_request/requirements.md
@@ -90,6 +90,7 @@ Returns a list of data requests with added information on requester user ("princ
       }
     ],
     "project": {
+      "id": 0, // number (int)
       "title": "", // string
       "description": "" // string
     },
@@ -145,6 +146,7 @@ Updates a data request. Only certain properties are available to updates (see Re
     }
   ],
   "project": {
+    "id": 0, // number (int)
     "title": "", // string
     "description": "" // string
   },

--- a/GEN3/project_request/requirements.md
+++ b/GEN3/project_request/requirements.md
@@ -68,6 +68,94 @@ Create a new project request. Based on the data returned by the searches it will
 
 Same as the `GET /projects` response.
 
+## GET /requests
+
+Returns a list of data requests with added information on requester user ("principal investigator"). Handles query string `?consortium={consortium_name}` to filter the list by consortium.
+
+```jsonc
+[
+  {
+    "id": 0, // number (int)
+    "consortium": "", // string
+    "state": "", // string
+    "submitted_at": "", // string (timestamp) or null
+    "completed_at": "", // string (timestamp) or null
+    "attributes": [
+      {
+        "id": 0, // number (int)
+        "name": "", // string
+        "type": "", // string
+        "value": "", // string
+        "optional": true // bool
+      }
+    ],
+    "project": {
+      "title": "", // string
+      "description": "" // string
+    },
+    "researcher": {
+      "first_name": "", // string
+      "last_name": "", // string
+      "institution": "" // string
+    }
+  }
+]
+```
+
+## PATCH /requests/{request_id}
+
+Updates a data request. Only certain properties are available to updates (see Request body below). Returns an updated request object as response.
+
+### Request body
+
+```jsonc
+{
+  "state": "", // string
+  "submitted_at": "", // string (timestamp) or null
+  "completed_at": "", // string (timestamp) or null
+  "attributes": [
+    {
+      "id": 0, // number (int)
+      "value": "" // string
+    }
+  ],
+  "project": {
+    "title": "", // string
+    "description": "" // string
+  }
+}
+```
+
+### Response body
+
+```jsonc
+{
+  "id": 0, // number (int)
+  "consortium": "", // string
+  "state": "", // string
+  "submitted_at": "", // string (timestamp) or null
+  "completed_at": "", // string (timestamp) or null
+  "attributes": [
+    {
+      "id": 0, // number (int)
+      "name": "", // string
+      "type": "", // string
+      "value": "", // string
+      "optional": true // bool
+    }
+  ],
+  "project": {
+    "title": "", // string
+    "description": "" // string
+  },
+  "researcher": {
+    "first_name": "", // string
+    "last_name": "", // string
+    "institution": "" // string
+  }
+}
+```
+
 ## POST /attributes
 
 Add an attribute to a request.

--- a/GEN3/project_request/requirements.md
+++ b/GEN3/project_request/requirements.md
@@ -138,20 +138,6 @@ User actions are one of the following: `SUBMIT`, `REQUEST_UPDATE`, `APPROVE`, an
 }
 ```
 
-## POST /attributes
-
-Add an attribute to a request.
-
-### Request body:
-
-```jsonc
-{
-  "project_id": 0, // number (int)
-  "attribute_id": 0, // number (int)
-  "value": "" // string
-}
-```
-
 ## GET /auth_url
 
 Returns a presigned_url for the user to use to upload a file in S3.
@@ -161,25 +147,6 @@ Returns a presigned_url for the user to use to upload a file in S3.
 ```jsonc
 {
   "url": "" // string
-}
-```
-
-## GET /submit/{request_id}
-
-Checks if all the requested attributes for the state to change have been associated to the project request. If so it will move the request to the next state, otehrwise it will return a list of the missing items.
-
-### Response body:
-
-```jsonc
-{
-  "attribute_missing": [
-    {
-      "id": 0, // number (int)
-      "name": "", // string
-      "type": "" // string
-    }
-  ],
-  "state": "" // string
 }
 ```
 

--- a/GEN3/project_request/requirements.md
+++ b/GEN3/project_request/requirements.md
@@ -69,6 +69,28 @@ Create a new project request. Based on the data returned by the searches it will
 
 Same as the `GET /projects` response.
 
+## PATCH /projects/{project_id}
+
+Updates project data. Only name and description values are available to updates (see Request body below).
+
+### Request body:
+
+```jsonc
+{
+  "name": "", // string
+  "description": "" // string
+}
+```
+
+### Response body:
+
+```jsonc
+{
+  "status": 200, // number (int; HTTP status code)
+  "error": "" //string
+}
+```
+
 ## GET /requests
 
 Returns a list of data requests with added information on requester user ("principal investigator"). Handles query string `?consortium={consortium_name}` to filter the list by consortium.

--- a/GEN3/project_request/requirements.md
+++ b/GEN3/project_request/requirements.md
@@ -103,60 +103,6 @@ Returns a list of data requests with added information on requester user ("princ
 ]
 ```
 
-## PATCH /requests/{request_id}
-
-Updates a data request. Only certain properties are available to updates (see Request body below). Returns an updated request object as response.
-
-### Request body
-
-```jsonc
-{
-  "submitted_at": "", // string (timestamp) or null
-  "completed_at": "", // string (timestamp) or null
-  "attributes": [
-    {
-      "id": 0, // number (int)
-      "value": "" // string
-    }
-  ],
-  "project": {
-    "title": "", // string
-    "description": "" // string
-  }
-}
-```
-
-### Response body
-
-```jsonc
-{
-  "id": 0, // number (int)
-  "consortium": "", // string
-  "state": "", // string
-  "submitted_at": "", // string (timestamp) or null
-  "completed_at": "", // string (timestamp) or null
-  "attributes": [
-    {
-      "id": 0, // number (int)
-      "name": "", // string
-      "type": "", // string
-      "value": "", // string
-      "optional": true // bool
-    }
-  ],
-  "project": {
-    "id": 0, // number (int)
-    "title": "", // string
-    "description": "" // string
-  },
-  "researcher": {
-    "first_name": "", // string
-    "last_name": "", // string
-    "institution": "" // string
-  }
-}
-```
-
 ## POST /user-action
 
 Dispatches a user action, which triggers updates to the relevant data request's `state` as well as `attributes`.

--- a/GEN3/project_request/requirements.md
+++ b/GEN3/project_request/requirements.md
@@ -157,6 +157,41 @@ Updates a data request. Only certain properties are available to updates (see Re
 }
 ```
 
+## POST /user-action
+
+Dispatches a user action, which triggers updates to the relevant data request's `state` as well as `attributes`.
+
+User actions are one of the following: `SUBMIT`, `REQUEST_UPDATE`, `APPROVE`, and `REJECT`. Action type `SUBMIT` is only avilable to requester ("researcher") user, and the other three action types are only available to reviewer user. Updating `attributes` is available for `SUBMIT` action only.
+
+### Request body
+
+```jsonc
+{
+  "type": "", // string ("SUBMIT" | "REQUEST_UPDATE" | "APPROVE" | "REJECT")
+  "payload": {
+    // request_id is required for all action types
+    "request_id": 0, // number (int)
+
+    // attributes is available for "SUBMIT" action type only
+    "attributes": [
+      {
+        "id": 0, // number (int)
+        "value": "" // string
+      }
+    ]
+  }
+}
+```
+
+### Response body:
+
+```jsonc
+{
+  "status": 200, // number (int; HTTP status code)
+  "error": "" //string
+}
+```
+
 ## POST /attributes
 
 Add an attribute to a request.


### PR DESCRIPTION
Ticket: [PEDS-301](https://pcdc.atlassian.net/browse/PEDS-301)

This PR adds `/requests` endpoint to data request API, which can be used to fetch a list of data requests for a specific consortium as well as to update a specific data request.