### PR TITLE
Update data requests /messages API PEDS-301

### DIFF
--- a/GEN3/project_request/requirements.md
+++ b/GEN3/project_request/requirements.md
@@ -17,6 +17,7 @@ Returns a list of project requests. If the user is a requester it would be a lis
     "name": "", // string
     "description": "", // string
     "researcher": {
+      "id": 0, // number (int)
       "first_name": "", // string
       "last_name": "", // string
       "institution": "" // string
@@ -119,6 +120,7 @@ Returns a list of data requests with added information on requester user ("princ
       "description": "" // string
     },
     "researcher": {
+      "id": 0, // number (int)
       "first_name": "", // string
       "last_name": "", // string
       "institution": "" // string

--- a/GEN3/project_request/requirements.md
+++ b/GEN3/project_request/requirements.md
@@ -178,7 +178,7 @@ Returns a presigned_url for the user to use to upload a file in S3.
 
 ## GET /messages
 
-Returns a list of messages the user sent or received
+Returns a list of messages for each request. Handles query string `?request_id={request_id}` to filter the list by request.
 
 ### Response body:
 
@@ -196,14 +196,6 @@ Returns a list of messages the user sent or received
   }
 ]
 ```
-
-## GET /messages/{request_id}
-
-Returns a list of messages the user sent or received pertinent to a specific request
-
-### Response body:
-
-Same as the `GET /messages` response.
 
 ## POST /message
 

--- a/GEN3/project_request/requirements.md
+++ b/GEN3/project_request/requirements.md
@@ -183,10 +183,14 @@ Returns a list of messages the user sent or received
 ```jsonc
 [
   {
-    "sender_id": 0, // number (int)
+    "request_id": 0, // number (int)
+    "sender": {
+      "id": 0, // number (int)
+      "fist_name": "", // string
+      "last_name": "" // string
+    },
     "sent_at": "", // string (timestamp)
-    "body": "", // string
-    "sent_to": [] // array of number (int)
+    "body": "" // string
   }
 ]
 ```
@@ -197,16 +201,7 @@ Returns a list of messages the user sent or received pertinent to a specific req
 
 ### Response body:
 
-```jsonc
-[
-  {
-    "sent_at": "", // string (timestamp)
-    "body": "", // string
-    "sender_name": "", // string
-    "self": true // bool
-  }
-]
-```
+Same as the `GET /messages` response.
 
 ## POST /message
 


### PR DESCRIPTION
Ticket: [PEDS-301](https://pcdc.atlassian.net/browse/PEDS-301)

This PR modifies the /messages API endpoint spec. The modifications and their rationale are as follows:

* The new API unifies `GET /messages` and `GET /messages/{request_id}` to a single `GET /messages` with query string `?request_id={request_id}`. This avoids violating the common REST pattern where `{id}` following resources must be id for that resources. This is the same reason behind using `?consortium={consortium_name}` query string for `GET /requests` in #7.
* Each message response data now includes`request_id` so that the frontend can utilize the already stored information on the related request to render message UI.
* Each message response data now includes `sender.id` so that the frontend can utilize the already stored information on the user to (1) identify whether the sender and current user are the same user (i.e. is self) and (2) identify whether the sender is the researcher who created the data request.
    * (1) is made available by the `/user/user` response
    * (2) is made available by the request object (by commit bdbe350 in the current PR)
* The new API removes the list of recipient ids (`sent_to`) from the message object as the frontend cannot use the information in any meaningful way.