### PR TITLE
Update data request API for file upload PEDS-301

### DIFF
--- a/GEN3/project_request/requirements.md
+++ b/GEN3/project_request/requirements.md
@@ -166,7 +166,7 @@ User actions are one of the following: `SUBMIT`, `REQUEST_UPDATE`, `APPROVE`, an
 
 ## POST /file_upload_url
 
-Returns a pre-signed URL for uploading a file to S3. The frontend application can then make a `PUT` request to upload binary data directly to the signed URL where the body is a blob.
+Returns a pre-signed URL for uploading a file to S3. The frontend application can then make a `PUT` request to upload binary data directly to the signed URL.
 
 ### Request body:
 

--- a/GEN3/project_request/requirements.md
+++ b/GEN3/project_request/requirements.md
@@ -164,9 +164,17 @@ User actions are one of the following: `SUBMIT`, `REQUEST_UPDATE`, `APPROVE`, an
 }
 ```
 
-## GET /auth_url
+## POST /file_upload_url
 
-Returns a presigned_url for the user to use to upload a file in S3.
+Returns a pre-signed URL for uploading a file to S3. The frontend application can then make a `PUT` request to upload binary data directly to the signed URL where the body is a blob.
+
+### Request body:
+
+```jsonc
+{
+  "filename": "" // string; {user_id}_{project_id}_{attribute_id}_{timestamp}.{ext}
+}
+```
 
 ### Response body:
 

--- a/GEN3/project_request/requirements.md
+++ b/GEN3/project_request/requirements.md
@@ -172,7 +172,7 @@ Returns a pre-signed URL for uploading a file to S3. The frontend application ca
 
 ```jsonc
 {
-  "filename": "" // string; {user_id}_{project_id}_{attribute_id}_{timestamp}.{ext}
+  "filename": "" // string; {user_id}_{request_id}_{attribute_id}_{timestamp}.{ext}
 }
 ```
 


### PR DESCRIPTION
Ticket: [PEDS-301](https://pcdc.atlassian.net/browse/PEDS-301)

This PR updates API endpoint to get pre-signed URL for file uploads to S3. The frontend application will then send a PUT request to the received URL with a file to upload as a blob.

Refer to the following articles on how-to:

* https://aws.amazon.com/blogs/compute/uploading-to-amazon-s3-directly-from-a-web-or-mobile-application/
* https://www.pluralsight.com/guides/uploading-files-with-reactjs
